### PR TITLE
Stop playback when `:stop!` fn is called

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,6 @@ What happens, exactly, at the beginning and end of an event, is determined by th
 
 ## License
 
-Copyright © 2016 Dave Yarwood et al
+Copyright © 2017 Dave Yarwood et al
 
 Distributed under the Eclipse Public License version 1.0.

--- a/build.boot
+++ b/build.boot
@@ -1,12 +1,13 @@
 (set-env!
   :source-paths   #{"src"}
   :dependencies   '[; dev
-                    [adzerk/bootlaces    "0.1.13" :scope "test"]
-                    [alda/core           "0.1.2"  :scope "test"]
+                    [adzerk/bootlaces            "0.1.13" :scope "test"]
+                    [alda/core                   "0.2.2"  :scope "test"]
+                    [org.clojure/tools.namespace "0.2.11" :scope "test"]
 
                     ; dependencies
-                    [com.taoensso/timbre "4.7.4"]
-                    [org.clojars.sidec/jsyn "16.7.3"]])
+                    [com.taoensso/timbre "4.10.0"]
+                    [com.jsyn/jsyn       "20170328"]])
 
 (require '[adzerk.bootlaces :refer :all])
 

--- a/src/alda/now.clj
+++ b/src/alda/now.clj
@@ -6,8 +6,7 @@
 
 (defn- prepare-audio-context!
   [score]
-  (let [audio-ctx (or (:audio-context @score) (sound/new-audio-context))]
-    (swap! score assoc :audio-context audio-ctx)))
+  (swap! score update :audio-context #(or % (sound/new-audio-context))))
 
 (defn new-score
   ([]
@@ -26,9 +25,8 @@
    audio types to set up will be determined based on the instruments in the
    score."
   [score & [audio-type]]
-  (let [audio-types (or audio-type (sound/determine-audio-types @score))]
-    (prepare-audio-context! score)
-    (sound/set-up! (:audio-context @score) audio-types @score)))
+  (prepare-audio-context! score)
+  (sound/set-up! @score audio-type))
 
 (defn tear-down!
   "Cleans up after a score after you're done using it.

--- a/src/alda/now.clj
+++ b/src/alda/now.clj
@@ -26,7 +26,7 @@
    score."
   [score & [audio-type]]
   (prepare-audio-context! score)
-  (sound/set-up! @score audio-type))
+  (sound/set-up! @score (or audio-type (sound/determine-audio-types score))))
 
 (defn tear-down!
   "Cleans up after a score after you're done using it.

--- a/src/alda/sound/midi.clj
+++ b/src/alda/sound/midi.clj
@@ -62,7 +62,7 @@
   (if *midi-synth*
     (do
       (log/debug "Using the global *midi-synth*")
-      *midi-synth*)
+      (doto *midi-synth* .open))
     (do
       (fill-midi-synth-pool!)
       (drain-excess-midi-synths!)
@@ -188,3 +188,7 @@
           channel        (aget channels channel-number)]
       (log/debug "MIDI note off:" midi-note)
       (.noteOff ^MidiChannel channel midi-note))))
+
+(defn all-sound-off!
+  [audio-ctx]
+  (->> @audio-ctx :midi-synth .getChannels (pmap #(.allSoundOff %))))


### PR DESCRIPTION
A first step for #3.

To stop playback, I opted to just tear down the audio context.

Open question: this seems fine in the context of an Alda worker bailing and re-opening the MIDI synth -- i.e. score playback is intended to be a one-off thing and the caller is responsible for setting things back up if it wants to play again. I tested this in the Alda REPL and at the command-line and it worked fine. But what about `alda.now` usage? May need to test that and possibly rethink this a little. It may be that it would be better to implement a `stop-events!` multimethod (e.g. `.setMute` for MIDI), clear the queue, and prevent any further events from being scheduled.