### PR TITLE
Basic Support for Playback of Sequences

### DIFF
--- a/src/alda/sound.clj
+++ b/src/alda/sound.clj
@@ -302,13 +302,10 @@
       (.recordEnable currentTrack -1)
       (.startRecording))
     ;; Pipe events into recorder
+    (midi/load-instruments-receiver! score receiver)
     (doseq [{:keys [offset instrument duration midi-note volume] :as event} events]
       (let
           [channel-number (-> instrument midi-channels :channel)
-           ;; channel        (aget channels channel-number)
-
-           instrumentMessage (doto (new ShortMessage)
-                               (.setMessage ShortMessage/PROGRAM_CHANGE channel-number 25 0))
 
            playMessage (doto (new ShortMessage)
                          (.setMessage ShortMessage/NOTE_ON channel-number midi-note
@@ -319,7 +316,6 @@
                                         (* 127 volume))))
            offset (* offset 1000)
            duration (* duration 1000)]
-        (.send receiver instrumentMessage offset)
         (.send receiver playMessage offset)
         (when stopMessage
           (.send receiver stopMessage (+ offset duration)))))

--- a/src/alda/sound.clj
+++ b/src/alda/sound.clj
@@ -289,18 +289,18 @@
 
 
 (defn score-to-sequence
-  [events score sequencer]
+  [events score]
   (let [{:keys [instruments audio-context]} score
         {:keys [midi-synth midi-channels]} @audio-context
         channels  (.getChannels ^Synthesizer midi-synth)
 
         ;; TODO make resolution configurable
         seq (new Sequence Sequence/PPQ Sequence/SMPTE_24)
+        sequencer (doto (MidiSystem/getSequencer false) .open)
         receiver (.getReceiver sequencer)
         currentTrack (.createTrack seq)]
     ;; warm up the recorder
     (doto sequencer
-      .open
       (.setSequence seq)
       (.setTickPosition 0)
       (.recordEnable currentTrack -1)
@@ -380,9 +380,7 @@
     (if *use-midi-sequencer*
       ;; play with midi sequencer
       (midi/play-sequence!
-       (score-to-sequence events score
-                          (doto (MidiSystem/getSequencer false)
-                            .open))
+       (score-to-sequence events score)
        #(deliver wait :done))
       ;; play with jsyn
       (do

--- a/src/alda/sound.clj
+++ b/src/alda/sound.clj
@@ -283,7 +283,7 @@
                                (/ (score-length events) 1000.0)
                                1) end!)))
 
-(defn record!
+(defn record-midi!
   [events score]
   ;; TODO What does PPQ mean? is 24 good? Probably need args for that
   (let [{:keys [instruments audio-context]} score
@@ -307,10 +307,10 @@
                          (doto (new ShortMessage)
                            (.setMessage ShortMessage/NOTE_OFF midi-note
                                         (* 127 volume))))]
-        (doto receiver (.send playMessage (* offset 1000)))
+        (.send receiver playMessage (* offset 1000))
         (when stopMessage
-          (doto receiver (.send stopMessage (+ (* offset 1000)
-                                               (* duration 1000)))))))
+          (.send receiver stopMessage (+ (* offset 1000)
+                                         (* duration 1000))))))
     ;; Stop our recorder
     (doto sequencer
       .stopRecording
@@ -356,7 +356,7 @@
         events      (-> (or event-set (:events score))
                         (shift-events start' end))]
     (log/debug "Scheduling events...")
-    (record! events score)
+    (record-midi! events score)
     (schedule-events! events score playing? wait)
     (cond
       (and one-off? async?)       (future @wait (tear-down! score))

--- a/src/alda/sound.clj
+++ b/src/alda/sound.clj
@@ -8,6 +8,7 @@
            [com.jsyn.engine SynthesisEngine]
            [javax.sound.midi Sequence]
            [javax.sound.midi MidiSystem]
+           [javax.sound.midi MidiDevice]
            [javax.sound.midi ShortMessage]
            [javax.sound.midi Synthesizer]
            [java.io File]
@@ -381,10 +382,13 @@
                         (shift-events start' end))]
     (log/debug "Scheduling events...")
     (if *use-midi-sequencer*
-      (let [sequencer (doto (MidiSystem/getSequencer) .open)]
-        (schedule-wait! score (midi/play-sequence! sequencer
-                                                   (score-to-sequence events score sequencer))
+      (let [sequencer (doto (MidiSystem/getSequencer false) .open)]
+        (schedule-wait! score
+                        (midi/play-sequence!
+                         sequencer
+                         (score-to-sequence events score sequencer))
                         wait))
+
 
       (schedule-events! events score playing? wait))
     (cond

--- a/src/alda/sound.clj
+++ b/src/alda/sound.clj
@@ -306,7 +306,7 @@
       (.recordEnable currentTrack -1)
       (.startRecording))
     ;; Pipe events into recorder
-    (midi/load-instruments-receiver! score receiver)
+    (midi/load-instruments! nil score receiver)
     (doseq [{:keys [offset instrument duration midi-note volume] :as event} events]
       (let
           [volume (* 127 volume)

--- a/src/alda/sound/midi.clj
+++ b/src/alda/sound/midi.clj
@@ -121,7 +121,8 @@
 (defn- load-instrument-receiver! [patch-number ^Integer channel-number receiver]
   (let [instrumentMessage (doto (new ShortMessage)
                             (.setMessage ShortMessage/PROGRAM_CHANGE
-                                         channel-number patch-number 0))]
+                                         ;; TODO why does this need to be -1
+                                         channel-number (dec patch-number) 0))]
     (.send receiver instrumentMessage 0)))
 
 (defn load-instruments-receiver!
@@ -214,3 +215,11 @@
       .getChannels
       (pmap stop-channel!)
       doall)))
+
+(defn play-sequence!
+  "Plays a sequence on a java midi sequencer."
+  [sequence]
+  (doto (MidiSystem/getSequencer)
+    (.open)
+    (.setSequence sequence)
+    (.start)))

--- a/src/alda/sound/midi.clj
+++ b/src/alda/sound/midi.clj
@@ -218,7 +218,7 @@
 
 (defn play-sequence!
   "Plays a sequence on a java midi sequencer."
-  [sequence]
+  [sequencer sequence]
   (doto (MidiSystem/getSequencer)
     (.open)
     (.setSequence sequence)

--- a/src/alda/sound/midi.clj
+++ b/src/alda/sound/midi.clj
@@ -219,7 +219,11 @@
 (defn play-sequence!
   "Plays a sequence on a java midi sequencer."
   [sequencer sequence]
-  (doto (MidiSystem/getSequencer)
+  ;; Set the sequencer to use our midi synth
+  (.setReceiver (.getTransmitter sequencer)
+                (.getReceiver *midi-synth*))
+  ;; Play the sequencer
+  (doto sequencer
     (.open)
     (.setSequence sequence)
     (.start)))


### PR DESCRIPTION
This has 80% of the work required to complete https://github.com/alda-lang/alda-sound-engine-clj/issues/2 (as well as midi export on top of that). Most of the work needed after that is setting up new alda commands between core and the client and we should be good to go.

To keep things as simple as possible, I'm only adding basic support for playback of sequences right now, and not actual midi export (with a lot of things missing, such as pause/stop). However, adding a line like this is all that's needed to get midi export:

```
(MidiSystem/write seq 0 (new File "test.mid"))
```

As far as I can tell, the output from synthesizers seem identical to jsyn. Right now, there's a bit of lag when starting to play a new sequence, but I think that can be solved by waiting a little bit before starting to play music. The actual exported files don't seem to be affected by this lag.

This is still very rough, so please let me know what I'm doing wrong! I'm not entirely sure if I got the async stuff right, I haven't done anything like it before.

[This page, linked by wasamasa, helped a lot for the final push in this](http://archive.oreilly.com/pub/a/onjava/excerpt/jenut3_ch17/index1.html)

Here's my [favorite alda score in midi](https://github.com/joshhting/alda-music/blob/master/PotentialForAnything.alda), now with all the instruments working!

[PotentialForAnything.zip](https://github.com/alda-lang/alda-sound-engine-clj/files/1485007/PotentialForAnything.zip)
