### PR TITLE
Finish midi sequencer and export

### DIFF
--- a/build.boot
+++ b/build.boot
@@ -6,8 +6,7 @@
                     [org.clojure/tools.namespace "0.2.11" :scope "test"]
 
                     ; dependencies
-                    [com.taoensso/timbre "4.10.0"]
-                    [com.jsyn/jsyn       "20170328"]])
+                    [com.taoensso/timbre "4.10.0"]])
 
 (require '[adzerk.bootlaces :refer :all])
 

--- a/src/alda/sound.clj
+++ b/src/alda/sound.clj
@@ -345,7 +345,6 @@
         _           (log/debug "Determining audio types...")
         score       (update score :audio-context #(or % (new-audio-context)))
         sequence    (apply create-sequence! score args)
-        playing?    (atom true)
         wait        (promise)]
     (log/debug "Scheduling events...")
     (midi/play-sequence! (:audio-context score) sequence #(deliver wait :done))
@@ -354,9 +353,7 @@
       (and one-off? (not async?)) (do @wait (tear-down! score))
       (not async?)                @wait)
     {:score score
-     :stop! #(do
-               (reset! playing? false)
-               (if one-off?
-                 (tear-down! score)
-                 (stop-playback! score)))
+     :stop! #(if one-off?
+               (tear-down! score)
+               (stop-playback! score))
      :wait  #(deref wait)}))

--- a/src/alda/sound.clj
+++ b/src/alda/sound.clj
@@ -244,9 +244,7 @@
 (defn score-to-sequence
   [events score]
   (let [{:keys [instruments audio-context]} score
-        {:keys [midi-synth midi-channels]} @audio-context
-        channels  (.getChannels ^Synthesizer midi-synth)
-
+        {:keys [midi-channels]} @audio-context
         ;; TODO make resolution configurable
         seq (new Sequence Sequence/PPQ Sequence/SMPTE_24)
         sequencer (doto (MidiSystem/getSequencer false) .open)

--- a/src/alda/sound.clj
+++ b/src/alda/sound.clj
@@ -302,13 +302,10 @@
       (.recordEnable currentTrack -1)
       (.startRecording))
     ;; Pipe events into recorder
+    (midi/load-instruments-receiver! score receiver)
     (doseq [{:keys [offset instrument duration midi-note volume] :as event} events]
       (let
           [channel-number (-> instrument midi-channels :channel)
-           ;; channel        (aget channels channel-number)
-
-           instrumentMessage (doto (new ShortMessage)
-                               (.setMessage ShortMessage/PROGRAM_CHANGE channel-number 25 0))
 
            playMessage (doto (new ShortMessage)
                          (.setMessage ShortMessage/NOTE_ON channel-number midi-note
@@ -319,7 +316,6 @@
                                         (* 127 volume))))
            offset (* offset 1000)
            duration (* duration 1000)]
-        (.send receiver instrumentMessage offset)
         (.send receiver playMessage offset)
         (when stopMessage
           (.send receiver stopMessage (+ offset duration)))))

--- a/src/alda/sound.clj
+++ b/src/alda/sound.clj
@@ -289,18 +289,18 @@
 
 
 (defn score-to-sequence
-  [events score sequencer]
+  [events score]
   (let [{:keys [instruments audio-context]} score
         {:keys [midi-synth midi-channels]} @audio-context
         channels  (.getChannels ^Synthesizer midi-synth)
 
         ;; TODO make resolution configurable
         seq (new Sequence Sequence/PPQ Sequence/SMPTE_24)
+        sequencer (doto (MidiSystem/getSequencer false) .open)
         receiver (.getReceiver sequencer)
         currentTrack (.createTrack seq)]
     ;; warm up the recorder
     (doto sequencer
-      .open
       (.setSequence seq)
       (.setTickPosition 0)
       (.recordEnable currentTrack -1)
@@ -380,9 +380,7 @@
     (if *use-midi-sequencer*
       ;; play with midi sequencer
       (midi/play-sequence!
-       (score-to-sequence events score
-                          (doto (MidiSystem/getSequencer false)
-                            .open))
+       (score-to-sequence events score)
        #(deliver wait :done))
       ;; play with jsyn
       (do

--- a/src/alda/sound.clj
+++ b/src/alda/sound.clj
@@ -283,7 +283,7 @@
                                (/ (score-length events) 1000.0)
                                1) end!)))
 
-(defn record!
+(defn record-midi!
   [events score]
   ;; TODO What does PPQ mean? is 24 good? Probably need args for that
   (let [{:keys [instruments audio-context]} score
@@ -307,10 +307,10 @@
                          (doto (new ShortMessage)
                            (.setMessage ShortMessage/NOTE_OFF midi-note
                                         (* 127 volume))))]
-        (doto receiver (.send playMessage (* offset 1000)))
+        (.send receiver playMessage (* offset 1000))
         (when stopMessage
-          (doto receiver (.send stopMessage (+ (* offset 1000)
-                                               (* duration 1000)))))))
+          (.send receiver stopMessage (+ (* offset 1000)
+                                         (* duration 1000))))))
     ;; Stop our recorder
     (doto sequencer
       .stopRecording
@@ -356,7 +356,7 @@
         events      (-> (or event-set (:events score))
                         (shift-events start' end))]
     (log/debug "Scheduling events...")
-    (record! events score)
+    (record-midi! events score)
     (schedule-events! events score playing? wait)
     (cond
       (and one-off? async?)       (future @wait (tear-down! score))

--- a/src/alda/sound.clj
+++ b/src/alda/sound.clj
@@ -8,6 +8,7 @@
            [com.jsyn.engine SynthesisEngine]
            [javax.sound.midi Sequence]
            [javax.sound.midi MidiSystem]
+           [javax.sound.midi MidiDevice]
            [javax.sound.midi ShortMessage]
            [javax.sound.midi Synthesizer]
            [java.io File]
@@ -381,10 +382,13 @@
                         (shift-events start' end))]
     (log/debug "Scheduling events...")
     (if *use-midi-sequencer*
-      (let [sequencer (doto (MidiSystem/getSequencer) .open)]
-        (schedule-wait! score (midi/play-sequence! sequencer
-                                                   (score-to-sequence events score sequencer))
+      (let [sequencer (doto (MidiSystem/getSequencer false) .open)]
+        (schedule-wait! score
+                        (midi/play-sequence!
+                         sequencer
+                         (score-to-sequence events score sequencer))
                         wait))
+
 
       (schedule-events! events score playing? wait))
     (cond

--- a/src/alda/sound.clj
+++ b/src/alda/sound.clj
@@ -94,8 +94,7 @@
 
    Playback may not necessarily be resumed after doing this."
   ([{:keys [audio-context] :as score}]
-   ;; TODO: implement teardown for MIDI Sequencer-based playback?
-   ,,,
+   (.close midi/*midi-sequencer*)
    ;; Do any necessary clean-up for each audio type.
    ;; e.g. for MIDI, close the MidiSynthesizer.
    (tear-down! score (determine-audio-types score)))
@@ -126,7 +125,7 @@
 (defn stop-playback!
   "Stop playback, but leave the score in a state where playback can be resumed."
   ([{:keys [audio-context] :as score}]
-   ;; TODO: implement stop-playback for MIDI Sequencer-based playback?
+   (.close midi/*midi-sequencer*)
    (stop-playback! score (determine-audio-types score)))
   ([{:keys [audio-context] :as score} audio-type]
    (if (coll? audio-type)

--- a/src/alda/sound.clj
+++ b/src/alda/sound.clj
@@ -306,7 +306,7 @@
       (.recordEnable currentTrack -1)
       (.startRecording))
     ;; Pipe events into recorder
-    (midi/load-instruments-receiver! score receiver)
+    (midi/load-instruments! nil score receiver)
     (doseq [{:keys [offset instrument duration midi-note volume] :as event} events]
       (let
           [volume (* 127 volume)

--- a/src/alda/sound/midi.clj
+++ b/src/alda/sound/midi.clj
@@ -121,7 +121,8 @@
 (defn- load-instrument-receiver! [patch-number ^Integer channel-number receiver]
   (let [instrumentMessage (doto (new ShortMessage)
                             (.setMessage ShortMessage/PROGRAM_CHANGE
-                                         channel-number patch-number 0))]
+                                         ;; TODO why does this need to be -1
+                                         channel-number (dec patch-number) 0))]
     (.send receiver instrumentMessage 0)))
 
 (defn load-instruments-receiver!
@@ -214,3 +215,11 @@
       .getChannels
       (pmap stop-channel!)
       doall)))
+
+(defn play-sequence!
+  "Plays a sequence on a java midi sequencer."
+  [sequence]
+  (doto (MidiSystem/getSequencer)
+    (.open)
+    (.setSequence sequence)
+    (.start)))

--- a/src/alda/sound/midi.clj
+++ b/src/alda/sound/midi.clj
@@ -218,7 +218,7 @@
 
 (defn play-sequence!
   "Plays a sequence on a java midi sequencer."
-  [sequence]
+  [sequencer sequence]
   (doto (MidiSystem/getSequencer)
     (.open)
     (.setSequence sequence)

--- a/src/alda/sound/midi.clj
+++ b/src/alda/sound/midi.clj
@@ -219,7 +219,11 @@
 (defn play-sequence!
   "Plays a sequence on a java midi sequencer."
   [sequencer sequence]
-  (doto (MidiSystem/getSequencer)
+  ;; Set the sequencer to use our midi synth
+  (.setReceiver (.getTransmitter sequencer)
+                (.getReceiver *midi-synth*))
+  ;; Play the sequencer
+  (doto sequencer
     (.open)
     (.setSequence sequence)
     (.start)))

--- a/src/alda/sound/midi.clj
+++ b/src/alda/sound/midi.clj
@@ -128,12 +128,13 @@ If receiver is provided, audio-ctx is not used at all."
   [audio-ctx score & [receiver]]
   (log/debug "Loading MIDI instruments into channels...")
   (let [midi-channels (ids->channels score)]
+    (when (not receiver)
+      (swap! audio-ctx assoc :midi-channels midi-channels))
     (doseq [{:keys [channel patch]} (set (vals midi-channels))
             :when patch]
       (if receiver
         (load-instrument-receiver! patch channel receiver)
-        (do (swap! audio-ctx assoc :midi-channels midi-channels)
-            (let [synth (:midi-synth @audio-ctx)
+        (do (let [synth (:midi-synth @audio-ctx)
                   channels (.getChannels ^Synthesizer synth)]
               (load-instrument! patch (aget channels channel))))))))
 

--- a/src/alda/sound/midi.clj
+++ b/src/alda/sound/midi.clj
@@ -15,13 +15,15 @@
   []
   (doto ^Synthesizer (MidiSystem/getSynthesizer) .open))
 
+(defn new-midi-sequencer
+  []
+  (MidiSystem/getSequencer false))
+
 (comment
   "When using separate worker processes, each process can have a single MIDI
    synth instance and use it to play one score at a time.")
 
 (def ^:dynamic *midi-synth* nil)
-
-(def ^:dynamic *midi-sequencer* (MidiSystem/getSequencer false))
 
 (def ^:const MIDI-END-OF-TRACK 0x2F)
 
@@ -221,27 +223,26 @@ If receiver is provided, audio-ctx is not used at all."
   "Plays a sequence on a java midi sequencer.
 
   Execute callback when sequence is done."
-  [sequence promise!]
-  (let [sequencer *midi-sequencer*]
-    (if (not (.isOpen sequencer))
-      (do
-        (.open sequencer)
-        ;; Set the sequencer to use our midi synth
-        (.setReceiver (.getTransmitter sequencer)
-                      (.getReceiver *midi-synth*))
-        ;; handle end of track
-        (.addMetaEventListener sequencer
-                               (proxy
-                                   [javax.sound.midi.MetaEventListener] []
-                                 (meta [event]
-                                   (when (= (.getType event) MIDI-END-OF-TRACK)
-                                     (.close sequencer)
-                                     (promise!)))))
-        ;; Play the sequencer
-        (doto sequencer
-          (.setSequence sequence)
-          .start))
-      (do
-        ;; Clear our play status
-        (promise!)
-        (log/debug "Attempted to play on an open sequencer!")))))
+  [sequencer sequence promise!]
+  (if (not (.isOpen sequencer))
+    (do
+      (.open sequencer)
+      ;; Set the sequencer to use our midi synth
+      (.setReceiver (.getTransmitter sequencer)
+        (.getReceiver *midi-synth*))
+      ;; handle end of track
+      (.addMetaEventListener sequencer
+        (proxy
+          [javax.sound.midi.MetaEventListener] []
+          (meta [event]
+            (when (= (.getType event) MIDI-END-OF-TRACK)
+              (.close sequencer)
+              (promise!)))))
+      ;; Play the sequencer
+      (doto sequencer
+        (.setSequence sequence)
+        .start))
+    (do
+      ;; Clear our play status
+      (promise!)
+      (log/debug "Attempted to play on an open sequencer!"))))


### PR DESCRIPTION
This change creates a separate midi sequencer each time you play, and opens/closes them similar to how it is done with the synth. This builds off of #10